### PR TITLE
Fixed a thing that can cause errors

### DIFF
--- a/src/main/java/me/checkium/vhackapi/vHackAPI.java
+++ b/src/main/java/me/checkium/vhackapi/vHackAPI.java
@@ -50,9 +50,9 @@ public class vHackAPI {
 	        stats = null;
 	}	
 		
-	public Others getOthers() {
-		Others others = new Others(username, password, userHash);
-		return others;
+	public PackageOpener getPackageOpener() {
+		PackageOpener packageOpener = new PackageOpener(username, password, userHash);
+		return packageOpener;
 	}
 	
 	public String getUsername(){

--- a/src/main/java/me/checkium/vhackapi/vHackAPI.java
+++ b/src/main/java/me/checkium/vhackapi/vHackAPI.java
@@ -15,6 +15,7 @@ public class vHackAPI {
 	protected String password;
 	protected String username;
 	protected String userHash;
+	private JSONObject stats = null;
 
 	
 	 public Console getConsole() {
@@ -32,16 +33,23 @@ public class vHackAPI {
 	 }	
 
 	public String getStats(Stats stat) {
-		try {
-			TimeUnit.MILLISECONDS.sleep(200);
-		} catch (InterruptedException e1) {
+		if(stats == null){
+		    try {
+		        TimeUnit.MILLISECONDS.sleep(200);
+		    } catch (InterruptedException e1) {
 			e1.printStackTrace();
+		    }
+		    stats = Utils.JSONRequest("user::::pass::::uhash", username + "::::" + password + "::::" + userHash, "vh_update.php");
+		    return json.getString(stat.toString());
+		} else {
+	            return json.getString(stat.toString());
 		}
-		JSONObject json = Utils.JSONRequest("user::::pass::::uhash", username + "::::" + password + "::::" + userHash, "vh_update.php");
-		
-		return json.getString(stat.toString());
 	}
 	
+	public void refreshStats() {
+	        stats = null;
+	}	
+		
 	public Others getOthers() {
 		Others others = new Others(username, password, userHash);
 		return others;


### PR DESCRIPTION
If you try a thing like
api.getStats(Stats.hdd);
api.getStats(Stats.cpu);
api.getStats(Stats.elo);
api.getStats(Stats.rank);
api.getStats(Stats.av);
api.getStats(Stats.adw);

It will return an error.

With this fix, the api will load the json once, then get all stats based on the loaded JSON.
I added a "refresh" method too, so the dev can refresh stats and get new one.